### PR TITLE
the "--dwell" parameter is required

### DIFF
--- a/run
+++ b/run
@@ -295,6 +295,7 @@ ${RUN_PRE} ${FSLDIR}/bin/fsl_sub ${QUEUE} ${FSLSUBOPTIONS} \
     --SEPhaseNeg="$SpinEchoPhaseEncodeNegative" \
     --SEPhasePos="$SpinEchoPhaseEncodePositive" \
     --echospacing="$DwellTime" \
+    --dwell="$DwellTime" \
     --seunwarpdir="$SEUnwarpDir" \
     --t1samplespacing="$T1wSampleSpacing" \
     --t2samplespacing="$T2wSampleSpacing" \


### PR DESCRIPTION
When running with SpinEchoFieldMap.

Errored without... but recorded as "success".